### PR TITLE
SOLID: Add userError auto-clear functionality

### DIFF
--- a/src/components/LogoutButton/LogoutButton.vue
+++ b/src/components/LogoutButton/LogoutButton.vue
@@ -5,6 +5,10 @@ const props = defineProps({
   onLogout: {
     type: Function,
     required: true
+  },
+  isLogOutLoading: {
+    type: Boolean,
+    default: false
   }
 })
 </script>
@@ -13,10 +17,27 @@ const props = defineProps({
   <button
     v-button-animation
     @click="onLogout"
-    class="group text-sm sm:text-xs lg:text-base text-green-500 hover:text-red-600 underline flex gap-1 sm:gap-1 lg:gap-2 items-center -mt-[2px] pb-[2px]"
+    class="group cursor-pointer text-sm sm:text-xs lg:text-base text-green-500 hover:text-red-600 font-semibold underline transition-all duration-200 ease-in-out flex gap-1 sm:gap-1 lg:gap-2 items-center -mt-[2px] pb-[2px]"
   >
-    <span v-if="isLoading" class="text-red-600">Loading...</span>
+    <span v-if="isLogOutLoading" class="text-red-600">Loading...</span>
     <span v-else class="group-hover:text-inherit">Log out</span>
     <LogoutIcon class="text-black group-hover:text-inherit" />
   </button>
 </template>
+
+<!-- <style scoped>
+/* text-[#48bb78] */
+button {
+  background: none;
+  border: none;
+  color: #48bb78;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+/* 
+button:hover {
+  color: #e53e3e; 
+} */
+</style> -->

--- a/src/components/UserInfo/UserIcon.vue
+++ b/src/components/UserInfo/UserIcon.vue
@@ -1,18 +1,36 @@
 <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    fill="currentColor"
-    height="24px"
-    width="24px"
-    version="1.1"
-    id="Layer_1"
-    viewBox="0 0 512 512"
-    xml:space="preserve"
+  <div
+    class="bg-gradient-to-r from-[#85e7ae] to-[#a7fcd1] ring-2 ring-white p-1 rounded-full scale-125 sm:scale-100 md:scale-105 lg:scale-125 shadow-md"
   >
-    <circle cx="256" cy="114.526" r="114.526" />
-    <path
-      d="M256,256c-111.619,0-202.105,90.487-202.105,202.105c0,29.765,24.13,53.895,53.895,53.895h296.421    c29.765,0,53.895-24.13,53.895-53.895C458.105,346.487,367.619,256,256,256z"
-    />
-  </svg>
+    <!-- <div class="user-icon-container"> -->
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      fill="currentColor"
+      height="18px"
+      width="18px"
+      version="1.1"
+      id="Layer_1"
+      viewBox="0 0 512 512"
+      xml:space="preserve"
+    >
+      <circle cx="256" cy="114.526" r="114.526" />
+      <path
+        d="M256,256c-111.619,0-202.105,90.487-202.105,202.105c0,29.765,24.13,53.895,53.895,53.895h296.421    c29.765,0,53.895-24.13,53.895-53.895C458.105,346.487,367.619,256,256,256z"
+      />
+    </svg>
+  </div>
 </template>
+
+<style scoped>
+.user-icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(135deg, #48bb78, #9cffc5); /* Градиент */
+  padding: 8px;
+  border-radius: 50%; /* Круглая форма */
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Легкая тень */
+  color: #fff; /* Белый цвет иконки */
+}
+</style>

--- a/src/components/UserInfo/UserInfo.vue
+++ b/src/components/UserInfo/UserInfo.vue
@@ -1,33 +1,25 @@
 <script setup>
 import UserIcon from './UserIcon.vue'
 import LogoutButton from '../LogoutButton/LogoutButton.vue'
-import { useMutation } from '@/composables/useMutation'
-import { getUserInfo } from '@/api/user'
-import { onMounted } from 'vue'
 
 const props = defineProps({
+  userInfo: {
+    type: Object,
+    default: null
+  },
+  isUserLoading: {
+    type: Boolean,
+    default: false
+  },
+  isLogOutLoading: {
+    type: Boolean,
+    default: false
+  },
   onLogout: {
     type: Function,
     required: true
   }
 })
-
-const {
-  data: userInfo,
-  mutation: getUser,
-  isLoading,
-  error
-} = useMutation({
-  mutationFn: () => getUserInfo()
-})
-
-onMounted(() => {
-  getUser()
-})
-
-if (error.value) {
-  console.error('Error fetching user info:', error.value)
-}
 
 // v-if="userInfo"
 </script>
@@ -37,16 +29,48 @@ if (error.value) {
     class="bg-white lg:max-w-[46%] rounded-lg shadow-md flex items-center gap-1 sm:gap-0 lg:gap-1 hover:bg-gray-100 transition"
   >
     <div
-      class="flex items-center px-1 sm:px-0 lg:px-1 justify-center w-6 sm:w-4 lg:w-8 bg-primary-100 rounded-full"
+      class="flex items-center px-1 ml-[6px] mr-1 sm:mx-1 md:mx-2 md:mr-[6px] lg:mx-1 sm:px-0 lg:px-1 justify-center w-6 sm:w-4 lg:w-8 rounded-full hover:scale-105 transition-transform duration-200"
     >
-      <UserIcon class="text-primary-600" />
+      <!-- <div class="icon-wrapper"> -->
+      <UserIcon class="text-black" />
     </div>
     <div class="flex-1 truncate">
-      <span v-if="isLoading" class="text-red-500">Loading...</span>
+      <span v-if="isUserLoading" class="text-red-500">Loading...</span>
       <span v-if="true" class="sticky font-semibold text-gray-900 text-sm sm:text-xs lg:text-base">
         {{ userInfo?.data?.name || 'Tom Cruise' }}
       </span>
-      <LogoutButton :onLogout="onLogout" />
+      <LogoutButton :onLogout="onLogout" :isLogOutLoading="isLogOutLoading" />
     </div>
   </div>
 </template>
+
+<!-- <style scoped>
+.user-info-container {
+  display: flex;
+  align-items: center;
+  /* padding: 12px; */
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.icon-wrapper {
+  /* margin-right: 10px; */
+}
+
+.user-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.loading-text {
+  color: #e53e3e;
+  font-size: 12px;
+}
+
+.user-name {
+  font-size: 14px;
+  font-weight: bold;
+  color: #1a202c;
+}
+</style> -->

--- a/src/views/HomepageView.vue
+++ b/src/views/HomepageView.vue
@@ -14,6 +14,7 @@ import { useMutation } from '@/composables/useMutation'
 import { useRouter } from 'vue-router'
 import { useModal } from '@/composables/useModal'
 import FullScreenButton from '@/components/IButton/FullScreenButton.vue'
+import { getUserInfo } from '@/api/user'
 
 const router = useRouter()
 
@@ -201,7 +202,17 @@ const handleAddPlace = async (formData) => {
 }
 
 const {
-  data,
+  data: userInfoData,
+  isLoading: isUserLoading,
+  error: userError,
+  mutation: getUser
+} = useMutation({
+  mutationFn: () => getUserInfo()
+})
+
+const {
+  data: logOutData,
+  isLoading: isLogOutLoading,
   error: logOutError,
   mutation: logOut
 } = useMutation({
@@ -229,6 +240,7 @@ const removeMarker = () => {
 }
 
 onMounted(() => {
+  getUser()
   if (!authService.isLoggedIn()) {
     console.warn('User is not authenticated. Redirecting to login page.')
     // favoritePlaces.value = favoritePlacesDefault
@@ -246,13 +258,6 @@ onMounted(() => {
         id="favorites-container"
         class="relative h-[33.1vh] bg-white sm:h-[100.1vh] md:w-[24%] sm:w-[28%] lg:w-[400px] shrink-0 pt-1 sm:pt-7 flex flex-col"
       >
-        <div
-          v-if="isPlacesLoading"
-          class="absolute z-10 text-[12px] sx:text-base text-primary left-3 md:left-1 sm:left-1 lg:left-6 top-[-5px] sm:top-[14px] lg:top-[14px]"
-        >
-          Loading...
-        </div>
-
         <!-- <div
           class="absolute flex justify-between -mt-2 md:-mt-3 sm:-mt-3 lg:-mt-3 gap-3 sm:gap-1 lg:gap-3 px-3 sm:px-1 lg:px-6 text-xs sm:text-[10px] lg:text-xs"
         >
@@ -262,14 +267,19 @@ onMounted(() => {
         </div> -->
 
         <FavoritePlaces
+          v-model:userError="userError"
           :items="favoritePlaces"
           :active-id="activeId"
           :is-places-loading="isPlacesLoading"
           @place-clicked="changePlace"
           @create="openModalWithErrorReset"
           @updated="getPlaces"
+          :user-info="userInfoData"
+          :is-user-loading="isUserLoading"
+          :user-error="userError"
           :on-logout="logOut"
-          :logout-data="data"
+          :logout-data="logOutData"
+          :is-log-out-loading="isLogOutLoading"
           :logout-error="logOutError"
         />
         <CreateNewPlaceModal


### PR DESCRIPTION
Implemented a watcher to automatically clear the userError prop after 5 seconds, ensuring cleaner UI and better user experience. The solution adheres to SOLID principles, making the logic modular and reusable while avoiding tight coupling. Added safeguards to reset timers when userError updates, preventing potential memory leaks or misfires.