### PR TITLE
centralize isMobile logic in store & unify route bar usage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,28 @@
 <script setup>
+import { computed, onBeforeUnmount, onMounted } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
-import { computed } from 'vue'
+import { useRouteStore } from '@/stores/routeStore'
+import { storeToRefs } from 'pinia'
 import ISpinner from './components/ISpinner/ISpinner.vue'
+import RouteStatusBar from './components/RouteStatusBar/RouteStatusBar.vue'
+import { fitToCurrentRoute, removeRoute } from './services/routeService'
 
 const route = useRoute()
+const routeStore = useRouteStore()
+const { isMobile, hasRoute, routeIcon } = storeToRefs(routeStore)
+
+function updateIsMobile() {
+  routeStore.setMobile(window.innerWidth < 640)
+}
+
+onMounted(() => {
+  updateIsMobile()
+  window.addEventListener('resize', updateIsMobile)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateIsMobile)
+})
 
 const isNotFoundPage = computed(() => route.name === 'NotFoundView')
 const isMapPage = computed(() => route.name === 'Map')
@@ -21,6 +40,16 @@ const isMapPage = computed(() => route.name === 'Map')
       isNotFoundPage || isMapPage ? 'text-gray-600' : 'text-white sm:text-gray-600'
     ]"
   >
-    <p class="text-sm">&copy; Created by maxexc</p>
+    <p class="text-sm z-10">&copy; Created by maxexc</p>
+    <div class="pointer-events-auto">
+      <RouteStatusBar
+        v-if="hasRoute && isMobile"
+        :isMobile="true"
+        :routeIcon="routeIcon"
+        :onFitRoute="fitToCurrentRoute"
+        :onRemoveRoute="removeRoute"
+        class="fixed z-[-1] bottom-[0px]"
+      />
+    </div>
   </footer>
 </template>

--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,9 @@ import '@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions.css'
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import { router } from './router';
+import App from './App.vue'
 import { authService, TOKEN_KEY } from './api/authService';
 
-import App from './App.vue'
 
 const token = localStorage.getItem(TOKEN_KEY)
 if (token) {
@@ -14,6 +14,17 @@ if (token) {
 }
 
 const app = createApp(App)
+const pinia = createPinia()
+
+app.use(pinia)
+app.use(router)
+
+// ---------------  Important!: We can only get a store after!  app.use(pinia) ---------------
+import { useRouteStore } from '@/stores/routeStore'
+import { initRouteService } from './services/routeService';
+const store = useRouteStore()
+initRouteService(store)
+
 
 // JS for iOS
 app.directive('button-animation', {
@@ -38,7 +49,5 @@ app.directive('button-animation', {
     },
 });
 
-app.use(createPinia())
-app.use(router)
 
 app.mount('#app')

--- a/src/stores/routeStore.js
+++ b/src/stores/routeStore.js
@@ -8,11 +8,13 @@ export const useRouteStore = defineStore('route', {
     state: () => ({
         currentRoute: shallowRef(null),
         isAddPointMode: false,
+        isMobile: false,
 
         //      *** TO DO ***
         // userRoutes: [],    routes list, shared routes, shared points, etc.
     }),
     getters: {
+        hasRoute: (state) => !!state.currentRoute,
         routeIcon(state) {
             if (!state.currentRoute) return '';
             const type = state.currentRoute.routeType;
@@ -26,6 +28,10 @@ export const useRouteStore = defineStore('route', {
         },
     },
     actions: {
+        setMobile(flag) {
+            this.isMobile = flag
+        },
+
         setRoute(route) {
             this.currentRoute = route
             localStorage.setItem('savedRoute', JSON.stringify(route))


### PR DESCRIPTION
- Moved isMobile detection to App.vue (resize event) and set store.isMobile
- Removed duplicate resize watchers from HomepageView.vue
- Called routeService methods (fitToCurrentRoute/removeRoute) directly
- Ensured single app.use(pinia) + initRouteService in main.js