### PR TITLE
fix auto-zoom in Safari + partial 3D coverflow fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>Vite App</title>
+  <title>VueMap-Explorer</title>
 </head>
 
 <body>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -325,3 +325,7 @@ min-height: -webkit-fill-available; */
 .marker-slider .swiper-slide-active {
   transform: translate3d(0, 0, 0) !important;
 }
+
+/* .marker-slider .swiper-slide {
+  transform: translate3d(0, 0, 0) !important;
+} */

--- a/src/components/EditPlaceModal/EditPlaceModal.vue
+++ b/src/components/EditPlaceModal/EditPlaceModal.vue
@@ -77,7 +77,7 @@ const handleChangeImg = (url) => {
   <IModal :is-show="isOpen" @close="emit('close')">
     <form
       @submit.prevent="emit('submit', formData)"
-      class="w-full sm:min-w-[570px] lg:min-w-[700px]"
+      class="w-full sx:w-[480px] sm:min-w-[570px] lg:min-w-[700px]"
     >
       <div class="flex gap-2 items-center justify-center sx:justify-normal mb-2 sx:ml-[2px]">
         <MarkerIcon class="w-5" />

--- a/src/components/FavoritePlaces/FavoritePlaces.vue
+++ b/src/components/FavoritePlaces/FavoritePlaces.vue
@@ -209,7 +209,7 @@ watch(
     </div>
   </div>
   <div
-    class="px-3 pt-0 lg:pt-1 mt-1 sm:mt-0 sm:px-1 lg:px-6 text-black h-full overflow-auto overflow-y-hidden"
+    class="px-3 pt-0 lg:pt-1 mt-1 sm:mt-0 sm:px-[2px] lg:px-6 text-black h-full overflow-auto overflow-y-hidden"
   >
     <div
       v-if="isPlacesLoading"

--- a/src/components/IButton/Toggle3DButton.vue
+++ b/src/components/IButton/Toggle3DButton.vue
@@ -14,7 +14,7 @@ const toggle3D = () => {
   <button
     v-button-animation
     @click="toggle3D"
-    class="z-10 top-[90px] right-[10px] bg-transparent rounded border-none cursor-pointer flex flex-col items-center gap-2 hover:bg-white"
+    class="z-10 top-[97px] right-[10px] bg-transparent rounded border-none cursor-pointer flex flex-col items-center gap-2 hover:bg-white"
   >
     <div
       class="icon"

--- a/src/components/SwiperSlider/SwiperSlider.vue
+++ b/src/components/SwiperSlider/SwiperSlider.vue
@@ -2,7 +2,9 @@
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import 'swiper/swiper-bundle.css'
 import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
-import { EffectCoverflow, Keyboard, Mousewheel } from 'swiper/modules'
+import { EffectCoverflow, Keyboard, Mousewheel, Navigation } from 'swiper/modules'
+import { useRouteStore } from '../../stores/routeStore'
+import { storeToRefs } from 'pinia'
 
 const props = defineProps({
   markers: {
@@ -100,12 +102,19 @@ const swiperDynamicSettings = computed(() => {
   }
 })
 
+const routeStore = useRouteStore()
+const { isIOS } = storeToRefs(routeStore)
+// isIOS.value = false
+console.log('isIOS: ', isIOS.value)
+
 const swiperSettings = computed(() => ({
-  effect: 'coverflow',
+  // effect: isIOS.value ? 'slide' : 'coverflow',
+  // effect: 'coverflow',
+  effect: !props.isMobile && isIOS.value ? 'slide' : 'coverflow',
   slidesPerView: swiperDynamicSettings.value.slidesPerView,
   grabCursor: true,
   centeredSlides: true,
-  spaceBetween: swiperDynamicSettings.value.spaceBetween,
+  spaceBetween: isIOS.value ? 10 : swiperDynamicSettings.value.spaceBetween,
   loop: true,
   direction: props.isMobile ? 'horizontal' : 'vertical',
   class: props.isMobile ? 'slider-vertical' : 'slider-horisontal',
@@ -116,7 +125,8 @@ const swiperSettings = computed(() => ({
   coverflowEffect: {
     rotate: 0,
     stretch: 0,
-    depth: swiperDynamicSettings.value.depth,
+    depth: isIOS.value ? 90 : swiperDynamicSettings.value.depth,
+    // depth: swiperDynamicSettings.value.depth,
     modifier: swiperDynamicSettings.value.modifier,
     slideShadows: false
   }
@@ -126,7 +136,7 @@ const swiperSettings = computed(() => ({
 <template>
   <Swiper
     v-bind="swiperSettings"
-    :modules="[Mousewheel, EffectCoverflow, Keyboard]"
+    :modules="[Mousewheel, Navigation, EffectCoverflow, Keyboard]"
     class="marker-slider"
     :mousewheel="{
       forceToAxis: true,
@@ -139,7 +149,12 @@ const swiperSettings = computed(() => ({
       }
     "
   >
-    <SwiperSlide v-for="marker in markers" :key="marker.id" @click="onCardClick(marker.id)">
+    <SwiperSlide
+      v-for="marker in markers"
+      :key="marker.id"
+      @click="onCardClick(marker.id)"
+      :class="{ 'px-[2px]': !isMobile }"
+    >
       <component
         :is="cardComponent"
         :id="marker.id"

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,26 @@ import { initRouteService } from './services/routeService';
 const store = useRouteStore()
 initRouteService(store)
 
+// bug-fix iOS overscaling
+store.detectPlatform()
+const metaViewport = document.querySelector("meta[name='viewport']")
+
+if (metaViewport) {
+    if (store.isIOS) {
+        // iOS: Turn off zoom
+        metaViewport.setAttribute(
+            'content',
+            'width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0'
+        )
+    } else {
+        // not iOS: allow user-scalable
+        metaViewport.setAttribute(
+            'content',
+            'width=device-width, initial-scale=1.0, viewport-fit=cover'
+        )
+        // additionally:  ,initial-scale=1.0, user-scalable=yes, maximum-scale=5.0
+    }
+}
 
 // JS for iOS
 app.directive('button-animation', {

--- a/src/stores/routeStore.js
+++ b/src/stores/routeStore.js
@@ -9,6 +9,7 @@ export const useRouteStore = defineStore('route', {
         currentRoute: shallowRef(null),
         isAddPointMode: false,
         isMobile: false,
+        isIOS: false,
 
         //      *** TO DO ***
         // userRoutes: [],    routes list, shared routes, shared points, etc.
@@ -46,6 +47,14 @@ export const useRouteStore = defineStore('route', {
                 this.currentRoute = JSON.parse(saved)
             }
         },
+        detectPlatform() {
+            const iOSRegex = /iPhone|iPad|iPod/i
+            // Additional iPadOS17 check for iOS to avoid overlapping panels
+            const isAppleTabletOS17 =
+                navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+
+            this.isIOS = iOSRegex.test(navigator.userAgent) || isAppleTabletOS17
+        }
 
 
         //      *** TO DO ***

--- a/src/views/HomepageView.vue
+++ b/src/views/HomepageView.vue
@@ -56,7 +56,9 @@ import { fitToCurrentRoute, removeRoute } from '@/services/routeService'
 const routeStore = useRouteStore()
 
 const router = useRouter()
-const { isMobile, currentRoute } = storeToRefs(routeStore) // destruct currentRoute for reactive tracking
+const { isMobile, currentRoute, isIOS } = storeToRefs(routeStore) // destruct currentRoute for reactive tracking
+console.log('isIOS in HW:', isIOS.value)
+alert(`isIOS in HW: ${isIOS.value}`)
 
 const is3DEnabled = ref(false)
 const activeId = ref(null)
@@ -420,18 +422,17 @@ async function saveGeojsonToFile(geojson) {
   }
 }
 
-const isIOS = ref(false)
+// const isIOS = ref(false)
 
-onMounted(() => {
-  isIOS.value = /iPhone|iPad|iPod/i.test(navigator.userAgent)
-  // alert(`iOS : ${isIOS.value}`)
-})
+// onMounted(() => {
+//   isIOS.value = /iPhone|iPad|iPod/i.test(navigator.userAgent)
+//   // alert(`iOS : ${isIOS.value}`)
+// })
 // class="relative min-h-screen overflow-auto bg-white" class="relative h-[100vh] overflow-auto bg-white"
-{
-  /* <section
+
+/* <section
     :class="['relative overflow-auto bg-white', isIOS ? 'section-ios' : 'section-android-desktop']"
   > */
-}
 </script>
 <template>
   <section
@@ -537,7 +538,7 @@ onMounted(() => {
           </MapboxMarker>
           <MapboxNavigationControl position="bottom-right" :showZoom="false" :showCompass="true" />
           <ResetZoomButton class="absolute" :mapInstance="mapInstance" :defaultZoom="10" />
-          <Toggle3DButton class="absolute" :is3DEnabled="is3DEnabled" @toggle3D="toggle3D" />
+          <Toggle3DButton class="fixed" :is3DEnabled="is3DEnabled" @toggle3D="toggle3D" />
           <FullScreenButton class="absolute bottom-[151px] right-[13px]" />
           <MapboxGeolocateControl
             position="bottom-left"


### PR DESCRIPTION
- Dynamically set meta[name="viewport"] to disable user-scalable on iOS only
- Extended detectPlatform in routeStore for iPadOS 17
- Adjusted Swiper coverflow for iOS (rotate=0, depth=90) for better clicks
- Unified isIOS usage in routeStore (removed local checks)