### PR TITLE
fix(iOS): address 5 major iOS bugs (auto-zoom, orientation scale, 3D …

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <!-- <meta name="apple-mobile-web-app-status-bar-style" content="default"> -->
   <title>VueMap-Explorer</title>
 </head>
 

--- a/src/components/IButton/Toggle3DButton.vue
+++ b/src/components/IButton/Toggle3DButton.vue
@@ -1,4 +1,8 @@
 <script setup>
+import { useRouteStore } from '@/stores/routeStore'
+
+const routeStore = useRouteStore()
+
 defineProps({
   is3DEnabled: Boolean
 })
@@ -14,7 +18,8 @@ const toggle3D = () => {
   <button
     v-button-animation
     @click="toggle3D"
-    class="z-10 top-[104px] right-[10px] bg-transparent rounded border-none cursor-pointer flex flex-col items-center gap-2 hover:bg-white"
+    class="z-10 right-[10px] bg-transparent rounded border-none cursor-pointer flex flex-col items-center gap-2 hover:bg-white"
+    :class="routeStore.isIOS ? 'top-[calc(env(safe-area-inset-top)+104px)]' : 'top-[90px]'"
   >
     <div
       class="icon"

--- a/src/components/SwiperSlider/SwiperSlider.vue
+++ b/src/components/SwiperSlider/SwiperSlider.vue
@@ -6,6 +6,9 @@ import { EffectCoverflow, Keyboard, Mousewheel, Navigation } from 'swiper/module
 import { useRouteStore } from '../../stores/routeStore'
 import { storeToRefs } from 'pinia'
 
+const routeStore = useRouteStore()
+const { isIOS } = storeToRefs(routeStore)
+
 const props = defineProps({
   markers: {
     type: Array,
@@ -102,11 +105,6 @@ const swiperDynamicSettings = computed(() => {
   }
 })
 
-const routeStore = useRouteStore()
-const { isIOS } = storeToRefs(routeStore)
-// isIOS.value = false
-console.log('isIOS: ', isIOS.value)
-
 const swiperSettings = computed(() => ({
   // effect: isIOS.value ? 'slide' : 'coverflow',
   // effect: 'coverflow',
@@ -122,12 +120,10 @@ const swiperSettings = computed(() => ({
   preventClicksPropagation: false,
   touchStartPreventDefault: false,
   touchMoveStopPropagation: false,
-  // slidesPerView: isIOS.value ? 2.7 : swiperDynamicSettings.value.slidesPerView,
   coverflowEffect: {
     rotate: 0,
     stretch: 0,
     depth: isIOS.value ? 0 : swiperDynamicSettings.value.depth,
-    // depth: swiperDynamicSettings.value.depth,
     modifier: swiperDynamicSettings.value.modifier,
     slideShadows: false
   }

--- a/src/main.js
+++ b/src/main.js
@@ -32,27 +32,11 @@ const metaViewport = document.querySelector("meta[name='viewport']")
 if (metaViewport) {
     if (store.isIOS) {
 
-        const userAgent = navigator.userAgent
-        const iPadDetect = /iPad/i.test(userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
-
-        if (iPadDetect) {
-            // iPad
-            metaViewport.setAttribute(
-                'content',
-                'width=device-width, initial-scale=0.999, viewport-fit=cover, user-scalable=no, maximum-scale=1.0'
-            )
-        } else {
-            // iPhone
-            metaViewport.setAttribute(
-                'content',
-                'width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0'
-            )
-        }
-        // // iOS: Turn off zoom
-        // metaViewport.setAttribute(
-        //     'content',
-        //     'width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0'
-        // )
+        // iOS: Turn off zoom
+        metaViewport.setAttribute(
+            'content',
+            'width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0'
+        )
     } else {
         // not iOS: allow user-scalable
         metaViewport.setAttribute(

--- a/src/views/HomepageView.vue
+++ b/src/views/HomepageView.vue
@@ -195,7 +195,7 @@ const handleMapClick = (event) => {
     directionsInstance.value.addWaypoint(index, [event.lngLat.lng, event.lngLat.lat])
 
     routeStore.isAddPointMode = false
-    console.log('Режим добавления точки отключен')
+    console.log('Add point mode is deactivated')
     showTemporaryWaypointsOnMap(mapInstance.value, directionsInstance.value)
 
     console.log('destination B point:', destination.geometry.coordinates)
@@ -349,7 +349,7 @@ function saveDirectionsConfig() {
 function restoreDirectionsConfig() {
   const map = mapInstance.value
   if (!savedDirectionsConfig.value) {
-    console.warn('[restoreDirectionsConfig] Нет сохранённой конфигурации')
+    console.warn('[restoreDirectionsConfig] No saved configuration')
     return
   }
   const currentStyle = map.getStyle()
@@ -393,7 +393,7 @@ function showRouteOnMap() {
 async function saveGeojsonToFile(geojson) {
   // Check API support
   if (!window.showSaveFilePicker) {
-    console.error('File System Access API не поддерживается этим браузером.')
+    console.error('File System Access API is not supported by this browser.')
     return
   }
 
@@ -477,6 +477,7 @@ async function saveGeojsonToFile(geojson) {
         </div>
         <RouteStatusBar
           v-if="currentRoute && !isMobile"
+          class="fixed bottom-1 z-10"
           :isMobile="false"
           :routeIcon="routeStore.routeIcon"
           :onFitRoute="fitToCurrentRoute"
@@ -524,11 +525,7 @@ async function saveGeojsonToFile(geojson) {
           </MapboxMarker>
           <MapboxNavigationControl position="bottom-right" :showZoom="false" :showCompass="true" />
           <ResetZoomButton class="absolute" :mapInstance="mapInstance" :defaultZoom="10" />
-          <Toggle3DButton
-            :class="routeStore.isIOS ? 'fixed' : 'absolute'"
-            :is3DEnabled="is3DEnabled"
-            @toggle3D="toggle3D"
-          />
+          <Toggle3DButton class="absolute" :is3DEnabled="is3DEnabled" @toggle3D="toggle3D" />
           <FullScreenButton class="absolute bottom-[151px] right-[13px]" />
           <MapboxGeolocateControl
             position="bottom-left"


### PR DESCRIPTION
…slider clicks, safe areas)

1) Disabled iOS auto-zoom by dynamically updating meta[name=viewport] (user-scalable=no, etc.) and splitting logic for iPhone / iPad. 2) Stopped Safari/PWA from jumping in scale when rotating device, plus fallback orientationchange fix. 3) Fixed Swiper coverflow on iOS: set depth=0, rotate=0 for clickable side slides, using routeStore.isIOS to handle it. 4) Added safe-area insets for UI elements (Toggle3DButton and RouteStatusBar), ensuring they don’t hide behind status bar or home indicator. 5) Adjusted top offsets for iOS, repositioning the 3D button with env(safe-area-inset-top).

All critical iOS display & click bugs are now resolved. Moving on to further server integration.